### PR TITLE
piJapi 105 axis2 update

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
@@ -1237,11 +1237,6 @@ public class HPCCFileSprayClient extends BaseHPCCWsClient
             log.error("File download failed. Drop zone file enumeration failed with error: " + e.getMessage());
             return -1;
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            log.error("File download failed. Drop zone file enumeration failed with error: " + e.getMessage());
-            return -1;
-        }
 
         URL downloadURL = null;
         try

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
@@ -471,11 +471,7 @@ public class HPCCWsClient extends DataSingleton
         }
         catch (Exception e)
         {
-            e.printStackTrace();
-        }
-        catch (org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
-        {
-            log.error(e.toString());
+            log.error(e.toString(),e);
         }
 
         return null;
@@ -539,7 +535,7 @@ public class HPCCWsClient extends DataSingleton
         {
             log.error("Error: Could not spray file" + e.getLocalizedMessage());
         }
-        catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
         }
@@ -630,7 +626,7 @@ public class HPCCWsClient extends DataSingleton
         {
             log.error("Error: Could not spray file" + e.getLocalizedMessage());
         }
-        catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
         }
@@ -721,7 +717,7 @@ public class HPCCWsClient extends DataSingleton
             else
                 throw new Exception("Could not initialize HPCC File Spray Client");
         }
-        catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
             return false;
@@ -746,7 +742,7 @@ public class HPCCWsClient extends DataSingleton
             else
                 throw new Exception("Could not initialize HPCC File Spray Client");
         }
-        catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
             return false;
@@ -776,10 +772,6 @@ public class HPCCWsClient extends DataSingleton
         {
             log.error("Error submitting ECL: " + e.getLocalizedMessage());
             throw e;
-        }
-        catch (ArrayOfECLExceptionWrapper | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
-        {
-            log.error("Error submitting ECL: " + e.toString());
         }
 
         return results;
@@ -820,10 +812,6 @@ public class HPCCWsClient extends DataSingleton
         catch (Exception e)
         {
             log.error("Error submitting ECL: " + e.getLocalizedMessage());
-        }
-        catch (ArrayOfECLExceptionWrapper | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
-        {
-            log.error("Error submitting ECL: " + e.toString());
         }
 
         return WUID;

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsSQLClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsSQLClient.java
@@ -297,7 +297,7 @@ public class HPCCWsSQLClient  extends BaseHPCCWsClient
                         success = true;
                 }
             }
-            catch (Exception | ArrayOfEspExceptionWrapper e) { log.error(e.getLocalizedMessage());}
+            catch (Exception e) { log.error(e.getLocalizedMessage());}
         }
         return success;
     }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Cluster.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Cluster.java
@@ -75,7 +75,7 @@ public class Cluster extends DataSingleton
                 TpClusterInfoResponse respsone = wsTopologyClient.getClusterInfo(info.getName());
                 Update(respsone);
         }
-        catch (Exception | ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
         }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DropZone.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DropZone.java
@@ -188,7 +188,7 @@ public class DropZone extends DataSingleton
         {
             update(platform.getWsClient().getWsTopologyClient().queryDropzoneMachines(dzInfo.getName()));
         }
-        catch (Exception | ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
         }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/FileSprayWorkunit.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/FileSprayWorkunit.java
@@ -193,7 +193,7 @@ public class FileSprayWorkunit extends DataSingleton
                 update(response.getResult());
             }
         }
-        catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
         }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/LogicalFile.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/LogicalFile.java
@@ -120,7 +120,7 @@ public class LogicalFile extends DataSingleton
             DFUInfoWrapper fileInfo = wsDfuClient.getFileInfo(dfulogicalfile.getName(), null);
             update(fileInfo.getFileDetail());
         }
-        catch (Exception | ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
         }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/PhysicalMachine.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/PhysicalMachine.java
@@ -151,7 +151,7 @@ public class PhysicalMachine extends DataSingleton
             PhysicalFileStructWrapper[] dzfiles = wsfsclient.listFiles(physicalmachinestruct.getNetaddress(), physicalmachinestruct.getDirectory(), null);
             update(dzfiles);
         }
-        catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             log.error("Could not refresh files list for PhysicalMachine: '" + physicalmachinestruct.getName() + "'");
             e.printStackTrace();

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Platform.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Platform.java
@@ -346,10 +346,6 @@ public class Platform extends DataSingleton
             {
                 e.printStackTrace();
             }
-            catch (ArrayOfEspExceptionWrapper e)
-            {
-                e.printStackTrace();
-            }
         }
         finally
         {
@@ -546,7 +542,7 @@ public class Platform extends DataSingleton
             {
                 confirmDisable();//rodrigo: we might need to confirmdisable for exception, or tighten up exceptions thrown
             }
-            catch (Exception | org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper e)
+            catch (Exception e)
             {
                 e.printStackTrace();
             }
@@ -768,7 +764,7 @@ public class Platform extends DataSingleton
                 if (services != null)
                     updateServices(services);
             }
-            catch (Exception | ArrayOfEspExceptionWrapper e)
+            catch (Exception e)
             {
                 e.printStackTrace();
                 confirmDisable();

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Workunit.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Workunit.java
@@ -498,7 +498,7 @@ public class Workunit extends DataSingleton
                     }
                 }
             } 
-            catch (Exception | ArrayOfEspExceptionWrapper ex) 
+            catch (Exception ex) 
             {
                 //getWUInfo throws the arrayofespexceptions wrapped in an exception;
                 //examine this in a catch

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/ArrayOfECLExceptionWrapper.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/ArrayOfECLExceptionWrapper.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.hpccsystems.ws.client.gen.axis2.wsworkunits.v1_75.ECLException;
 
-public class ArrayOfECLExceptionWrapper extends Throwable
+public class ArrayOfECLExceptionWrapper extends Exception
 {
     private static final long serialVersionUID = 1L;
     protected List<ECLExceptionWrapper> eclExceptions = new ArrayList<ECLExceptionWrapper>();
@@ -95,4 +95,9 @@ public class ArrayOfECLExceptionWrapper extends Throwable
     {
         return this.eclExceptions;
     }
+    @Override
+    public String getLocalizedMessage() {
+        return this.toString();
+    }
+
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/ArrayOfEspExceptionWrapper.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/ArrayOfEspExceptionWrapper.java
@@ -26,7 +26,7 @@ import java.util.List;
  * TimeStamp: 2019-08-03T01:15:45.768Z
  */
 
-public class ArrayOfEspExceptionWrapper extends Throwable
+public class ArrayOfEspExceptionWrapper extends Exception
 {
     private static final long serialVersionUID = 1L;
 
@@ -319,5 +319,10 @@ public class ArrayOfEspExceptionWrapper extends Throwable
 	public List<EspExceptionWrapper> getExceptions( )
 	{
 		return this.exceptions;
+	}
+	
+	@Override
+	public String getLocalizedMessage() {
+	    return this.toString();
 	}
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/wsworkunits/WorkunitWrapper.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/wsworkunits/WorkunitWrapper.java
@@ -2516,4 +2516,9 @@ public class WorkunitWrapper implements Comparable<org.hpccsystems.ws.client.wra
 
         return result;
     }
+
+    public void setExceptions(List<WUExceptionWrapper> errs)
+    {
+        this.exceptions=errs;
+    }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/FileSprayClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/FileSprayClientTest.java
@@ -119,7 +119,7 @@ public class FileSprayClientTest extends BaseRemoteTest
                 Assert.assertEquals(thisdz.getPath(), localdzs[i].getPath());
             }
         }
-        catch (Exception | ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             e.printStackTrace();
             Assert.fail();
@@ -134,7 +134,7 @@ public class FileSprayClientTest extends BaseRemoteTest
             DropZoneWrapper[] dzs = filesprayclient.fetchDropZones("invalidserver:8010");
             Assert.assertNull(dzs);
         }
-        catch (Exception | ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             System.out.println("Test fetch DropZones Bad URL failed as expected: " + e.getLocalizedMessage());
         }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSSQLClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSSQLClientTest.java
@@ -118,10 +118,6 @@ public class WSSQLClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
-        }
     }
 
     @Test
@@ -149,10 +145,6 @@ public class WSSQLClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
-        }
     }
 
     @Test
@@ -172,10 +164,6 @@ public class WSSQLClientTest extends BaseRemoteTest
         {
             e.printStackTrace();
             Assert.fail();
-        }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
         }
     }
 
@@ -242,10 +230,6 @@ public class WSSQLClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
-        }
     }
 
     @Test
@@ -277,10 +261,6 @@ public class WSSQLClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfECLExceptionWrapper | ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
-        }
     }
 
     @Test
@@ -309,11 +289,6 @@ public class WSSQLClientTest extends BaseRemoteTest
             catch (Exception e)
             {
                 System.out.println("Exception while executing SQL: " + e.getLocalizedMessage());
-            }
-            catch (ArrayOfEspExceptionWrapper e)
-            {
-                e.toString();
-                Assert.fail();
             }
 
             Assert.assertNotNull(wuid);
@@ -371,11 +346,6 @@ public class WSSQLClientTest extends BaseRemoteTest
                 {
                     System.out.println("Exception while fetching results related to WUID: " + wuid + ": " + e.getLocalizedMessage());
                 }
-                catch (ArrayOfEspExceptionWrapper e)
-                {
-                    e.toString();
-                    Assert.fail();
-                }
 
                 Assert.assertNotNull(filtercolumnname);
                 String filter1 = sql + " where mytable." + filtercolumnname + " != ?";// filtercolumntype == 1 ? "";
@@ -399,10 +369,6 @@ public class WSSQLClientTest extends BaseRemoteTest
         {
             e.printStackTrace();
             Assert.fail();
-        }
-        catch (ArrayOfECLExceptionWrapper | ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
         }
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSStoreClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSStoreClientTest.java
@@ -124,10 +124,6 @@ public class WSStoreClientTest extends BaseRemoteTest
         {
             Assert.fail(e.getLocalizedMessage());
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
-        }
     }
 
     @Test
@@ -143,10 +139,6 @@ public class WSStoreClientTest extends BaseRemoteTest
         catch (Exception e)
         {
             Assert.fail(e.getLocalizedMessage());
-        }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
         }
     }
 

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSWorkunitsTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSWorkunitsTest.java
@@ -85,10 +85,6 @@ public class WSWorkunitsTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
-        }
     }
 
     @Test
@@ -111,10 +107,6 @@ public class WSWorkunitsTest extends BaseRemoteTest
         catch (Exception e)
         {
             e.printStackTrace();
-            Assert.fail();
-        }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
             Assert.fail(e.toString());
         }
     }
@@ -141,10 +133,6 @@ public class WSWorkunitsTest extends BaseRemoteTest
         {
             e.printStackTrace();
             Assert.fail(e.getLocalizedMessage());
-        }
-        catch (ArrayOfECLExceptionWrapper | ArrayOfEspExceptionWrapper e)
-        {
-            Assert.fail(e.toString());
         }
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsDFUClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsDFUClientTest.java
@@ -134,11 +134,6 @@ public class WsDFUClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            e.toString();
-            Assert.fail();
-        }
     }
 
     public void getFirstFileAvailable(String directory)
@@ -168,11 +163,6 @@ public class WsDFUClientTest extends BaseRemoteTest
         catch (Exception e)
         {
             e.printStackTrace();
-            Assert.fail();
-        }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            e.toString();
             Assert.fail();
         }
     }
@@ -209,11 +199,6 @@ public class WsDFUClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            e.toString();
-            Assert.fail();
-        }
     }
 
     @Test
@@ -233,10 +218,6 @@ public class WsDFUClientTest extends BaseRemoteTest
             e.printStackTrace();
             Assert.fail();
         }
-        catch (ArrayOfEspExceptionWrapper e)
-        {
-            e.toString();
-            Assert.fail();
-        }
+
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/test/PlatformTester.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/test/PlatformTester.java
@@ -386,16 +386,11 @@ public class PlatformTester
             }
             catch (Exception e)
             {
+                e.printStackTrace();
                 System.out.println("Encountered issue while testing WsSQL on port: " + wssqlport + "\n>>" + e.getLocalizedMessage());
             }
-            catch (ArrayOfECLExceptionWrapper e)
-            {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-
         }
-        catch (Exception | ArrayOfEspExceptionWrapper e)
+        catch (Exception e)
         {
             System.out.println( e.getLocalizedMessage());
         }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/test/SerializeTester.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/test/SerializeTester.java
@@ -62,7 +62,7 @@ public class SerializeTester {
 			System.out.println("Class not found");
 			c.printStackTrace();
 		}
-		catch(Exception | ArrayOfEspExceptionWrapper e)
+		catch(Exception e)
 		{
 			e.getMessage();
 			e.printStackTrace();


### PR DESCRIPTION
so, it works a lot better for the salt/hpcc project (which is where the hipie hpcc integration migrated to, btw) if the ArrayOfEspExceptionWrapper and ArrayOfEclExceptionWrapper classes extend exception rather than throwable.

This PR makes that change, and updates the other wsclient classes to accommodate it. If you're cool with this change, you can accept this PR; if not, let's chat Monday about it.

Thanks,

Drea